### PR TITLE
Change template to use identifier for remote and local hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ USE_ENV_CONFIG=AWS
 # use this just in conjunction with calico and host networking
 SET_ROUTE_DEFAULT_TABLE=FALSE
 
-# local private IP of the AWS node the container is supposed to be running on
-IPSEC_LOCALPRIVIP=
+# local IP of the node the container is supposed to be running on
+# this IP has to able to be bound by the service and could also be '%any'
+IPSEC_LOCALIP=
 
-# corresponding local public IP of the AWS node
-IPSEC_LOCALPUBIP=
+# The local identifier to be used during the handshake.
+# This can either be an IP address, a FQDN, an email address or a distinguished
+# name. This value has to be the same as IPSEC_REMOTEID on the other side of
+# the tunnel.
+IPSEC_LOCALID=
 
 # local network to be shared over the VPN tunnel
 # used for leftid=
@@ -58,6 +62,9 @@ IPSEC_REMOTEIP=
 
 # remote network to be shared
 IPSEC_REMOTENET=
+
+# the remote identifier for the connection
+IPSEC_REMOTEID=
 
 # pre shared key to be used for the tunnel
 # this should be a long random string

--- a/config/ipsec.hidden_pubip_host.conf.tmpl
+++ b/config/ipsec.hidden_pubip_host.conf.tmpl
@@ -39,10 +39,11 @@ conn site-static-ip
 	also=sts-base
 	keyexchange={{getv "/keyexchange"}}
 	leftsubnet={{getv "/localnet"}}
-	left={{getv "/localprivip"}}
-	leftid={{getv "/localpubip"}}
+	left={{getv "/localip"}}
+	leftid={{getv "/localid"}}
 	rightsubnet={{getv "/remotenet"}}
 	right={{getv "/remoteip"}}
+    rightid={{getv "/remoteid"}}
 	auto=route
 	leftauth=psk
 	rightauth=psk

--- a/config/ipsec.hidden_pubip_host.secrets.tmpl
+++ b/config/ipsec.hidden_pubip_host.secrets.tmpl
@@ -1,2 +1,2 @@
 # ipsec.secrets - strongSwan IPsec secrets file
-{{getv "/remoteip"}} : PSK {{getv "/psk"}}
+{{getv "/remoteid"}} : PSK {{getv "/psk"}}

--- a/files/start-strongswan.sh
+++ b/files/start-strongswan.sh
@@ -52,8 +52,9 @@ then
       [ -z "$IPSEC_LOCALNET" ] && { echo "Need to set IPSEC_LOCALNET"; exit 1; }
       [ -z "$IPSEC_PSK" ] && { echo "Need to set IPSEC_PSK"; exit 1; }
       [ -z "$IPSEC_REMOTEIP" ] && { echo "Need to set IPSEC_REMOTEIP"; exit 1; }
-      [ -z "$IPSEC_LOCALPRIVIP" ] && { echo "Need to set IPSEC_LOCALPRIVIP"; exit 1; }
-      [ -z "$IPSEC_LOCALPUBIP" ] && { echo "Need to set IPSEC_LOCALPUBIP"; exit 1; }
+      [ -z "$IPSEC_REMOTEID" ] && { echo "Need to set IPSEC_REMOTEID"; exit 1; }
+      [ -z "$IPSEC_LOCALIP" ] && { echo "Need to set IPSEC_LOCALIP"; exit 1; }
+      [ -z "$IPSEC_LOCALID" ] && { echo "Need to set IPSEC_LOCALID"; exit 1; }
       [ -z "$IPSEC_REMOTENET" ] && { echo "Need to set IPSEC_REMOTENET"; exit 1; }
       [ -z "$IPSEC_KEYEXCHANGE" ] && { echo "Need to set IPSEC_KEYEXCHANGE"; exit 1; }
       [ -z "$IPSEC_ESPCIPHER" ] && { echo "Need to set IPSEC_ESPCIPHER"; exit 1; }

--- a/files/strongswan.hidden_pubip_host.config.toml
+++ b/files/strongswan.hidden_pubip_host.config.toml
@@ -3,9 +3,10 @@ src = "ipsec.hidden_pubip_host.conf.tmpl"
 prefix = "/ipsec"
 dest = "/etc/ipsec.config.d/ipsec.hidden_pubip_host.conf"
 keys = [
-    "/localprivip",
-    "/localpubip",
+    "/localip",
+    "/localid",
     "/remoteip",
+    "/remoteid",
     "/localnet",
     "/remotenet",
     "/keyexchange",

--- a/files/strongswan.hidden_pubip_host.secret.toml
+++ b/files/strongswan.hidden_pubip_host.secret.toml
@@ -3,6 +3,6 @@ src = "ipsec.hidden_pubip_host.secrets.tmpl"
 prefix = "/ipsec"
 dest = "/etc/ipsec.secrets.d/ipsec.hidden_pubip_host.secrets"
 keys = [
-    "/remoteip",
+    "/remoteid",
     "/psk"
 ]


### PR DESCRIPTION
* public IP address was used before as an identifier which resulted
  to falsy behaviour when source IP address and the remote IP address
  configuration of the other site did not match