### PR TITLE
disable farp plugin with module conf and remove manual load list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.1
+
+* disable `farp` plugin by default, which was desired but not executed before
+
 ## v1.3.0
 
 * add variable for interfaces to bind to

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,13 @@ RUN apk add --update --no-cache strongswan tcpdump iputils iproute2 && \
         mkdir -p /etc/confd/conf.d.disabled
 
 COPY --from=confd /app/bin/confd /usr/local/bin/confd
-ADD files/ipsec.conf /etc/ipsec.conf
-ADD files/ipsec.secrets /etc/ipsec.secrets
-ADD config/*.tmpl /etc/confd/templates/
-ADD files/strongswan.psk-template.config.toml /etc/confd/conf.d.disabled/
-ADD files/strongswan.psk-template.secret.toml /etc/confd/conf.d.disabled/
-ADD files/charon.conf.toml /etc/confd/conf.d.disabled/
-ADD files/start-strongswan.sh /usr/local/bin
+COPY files/ipsec.conf /etc/ipsec.conf
+COPY files/ipsec.secrets /etc/ipsec.secrets
+COPY config/*.tmpl /etc/confd/templates/
+COPY files/strongswan.psk-template.config.toml /etc/confd/conf.d.disabled/
+COPY files/strongswan.psk-template.secret.toml /etc/confd/conf.d.disabled/
+COPY files/charon.conf.toml /etc/confd/conf.d.disabled/
+COPY config/farp.conf /etc/strongswan.d/charon/
+COPY files/start-strongswan.sh /usr/local/bin
 
 ENTRYPOINT ["/usr/local/bin/start-strongswan.sh"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run the container execute the following section:
 ### Configuration
 
 Configuration is done by environment variables. See below for available options.
-Alternatively it is also possible to point $ENVFILE to an environment file which is sourced before startup.
+Alternatively it is also possible to point `$ENVFILE` to an environment file which is sourced before startup.
 
 ```sh
 # source specified file before startup.
@@ -145,6 +145,33 @@ The following ENVVARs are available:
 * `$IPSEC_INTERFACES`
 
 If you want to mount a configuration manually into the container, set `$IPSEC_MANUAL_CHARON` to anything, eg. `$IPSEC_MANUAL_CHARON=True` (unset or set to empty string will disable the option).
+
+#### enable or disable additional modules
+
+Due to the large amount of possible module combinations in the *charon* IKE daemon,
+you have to configure these manually, if you need special settings.
+
+This includes enable plugins, which are not enabled by default and
+disable plugins, which are not disabled by default.
+
+To do so, you have to create a file with the module configuration.
+As a starting point you can retrieve the current configuration from the `/etc/strongswan.d/charon`
+folder of the container.
+
+One example would be the `farp` module configuration.
+The current default is:
+
+```
+farp {
+
+    # Whether to load the plugin. Can also be an integer to increase the
+    # priority of this plugin.
+    load = no
+}
+```
+
+To overwrite this, you have to mount the file to `/etc/strongswan.d/charon/farp.conf`
+after adding you settings.
 
 ### VTI Interface
 

--- a/config/charon.conf.tmpl
+++ b/config/charon.conf.tmpl
@@ -177,7 +177,7 @@ charon {
     # keep_alive = 20s
 
     # Plugins to load in the IKE daemon charon.
-    load = mgf1,random,nonce,x509,revocation,constraints,pubkey,pkcs1,pkcs7,pkcs8,pkcs12,pgp,dnskey,sshkey,pem,openssl,fips-prf,gmp,curve25519,xcbc,cmac,curl,sqlite,attr,kernel-netlink,resolve,socket-default,stroke,vici,updown,eap-identity,eap-sim,eap-aka,eap-aka-3gpp2,eap-simaka-pseudonym,eap-simaka-reauth,eap-md5,eap-mschapv2,eap-radius,eap-tls,xauth-generic,xauth-eap,dhcp,unity,counters
+    # load = mgf1,random,nonce,x509,revocation,constraints,pubkey,pkcs1,pkcs7,pkcs8,pkcs12,pgp,dnskey,sshkey,pem,openssl,fips-prf,gmp,curve25519,xcbc,cmac,curl,sqlite,attr,kernel-netlink,resolve,socket-default,stroke,vici,updown,eap-identity,eap-sim,eap-aka,eap-aka-3gpp2,eap-simaka-pseudonym,eap-simaka-reauth,eap-md5,eap-mschapv2,eap-radius,eap-tls,xauth-generic,xauth-eap,dhcp,unity,counters
 
     # Determine plugins to load via each plugin's load option.
     # load_modular = no

--- a/config/farp.conf
+++ b/config/farp.conf
@@ -1,0 +1,7 @@
+farp {
+
+    # Whether to load the plugin. Can also be an integer to increase the
+    # priority of this plugin.
+    load = no
+
+}


### PR DESCRIPTION
Due to an error in the settings, the manual load list of plugins
for the charon daemon was not used by the software.
To be useful, `load_modular = yes` would have to be set.

Because of errors in module loading and discourage of using the
manual load list by the strongswan documentation, the modules will
now be configured by their respective configuration files.